### PR TITLE
feat(ml): add end-to-end ML training stack (base XGB, TCN, blender, m…

### DIFF
--- a/algo-data-ingestion/IMPLEMENT_WITH_YOUR_DATASETS.md
+++ b/algo-data-ingestion/IMPLEMENT_WITH_YOUR_DATASETS.md
@@ -1,0 +1,46 @@
+# Walkthrough: Implement with Your Datasets
+
+This document captures the end-to-end implementation plan using your datasets. It is actionable and aligned with the repository’s current structure and scripts.
+
+Datasets
+- Training (market-only): `datasets/market_btcusdt_1m_2024_2025.parquet`
+- Validation (market+RSS): `datasets/training_matrix_months_2025-08-09.parquet`
+
+Step 1: Preprocess
+- Ensure timestamp UTC and unique per bar (already enforced in our dataset builders).
+- For TCN, construct a sliding window tensor from the market dataset (e.g., last 32 bar deltas/returns; standardize per window).
+- For labels: use `y_dir`; optionally create higher-confidence labels (e.g., `|ret_next| > threshold` for positives) to train the meta-filter later.
+
+Step 2: Base Learner (GBDT)
+- Train XGBoost classifier on market features (no RSS) with walk-forward CV across 2024→2025 windows.
+- Calibrate predictions (Isotonic/Platt) on the backtest folds.
+- Save: base model + probability calibrator + feature list + chosen probability threshold.
+
+Step 3: Temporal Edge (Tiny TCN)
+- Inputs: short window (e.g., 32) of returns/ohlcv deltas; target `y_dir`.
+- Keep small (1–2 residual blocks, kernel size 3–5) to avoid overfit.
+- Calibrate outputs (map to probabilities).
+- Save: TCN model + scaler + calibrator + chosen threshold.
+
+Step 4: Combine (Stack/Blend)
+- Build a blender dataset on the validation month:
+  - Features: `base_prob`, `tcn_prob`, `rss_count`, `rss_sent_mean`, and regime features (e.g., `rvol_20`).
+  - Target: `y_dir` for the month.
+- Train a logistic blender (or shallow tree).
+- Threshold selection: choose `p*` that maximizes PnL with costs on the validation period.
+
+Step 5: Meta‑Labeling Filter (optional but recommended)
+- Generate events via triple‑barrier (profit‑taking, stop‑loss, time barrier).
+- Train logistic meta‑model to predict event success conditioned on base signals and TCN features.
+- Use meta‑prob to mask low‑quality trades before applying thresholds.
+
+Step 6: Risk & Execution
+- Volatility targeting: position size `s = k / recent_vol` (cap max size).
+- Dynamic threshold: `p* = c0 + alpha × (spread/vol)` to avoid trading when costs are high.
+- Turnover constraint: suppress flips within N minutes; apply small hysteresis between enter/exit thresholds.
+
+Step 7: Live Path (staged)
+- Feature store: read latest features from Redis; compute TCN inputs from recent history buffer.
+- Apply base + TCN; optional meta‑filter; blender; threshold to trade.
+- If RSS present live, feed RSS features; else fallback to base stack (blender should handle NaN/zero gracefully).
+

--- a/algo-data-ingestion/scripts/train_base_gbdt.py
+++ b/algo-data-ingestion/scripts/train_base_gbdt.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Optional, List, Dict
+
+import numpy as np
+import pandas as pd
+
+from training.data import load_parquet_dataset, ensure_labels
+from training.walkforward import time_folds
+from training.model import extract_features_labels, train_xgb, calibrate, predict_proba, save_artifacts
+from training.thresholds import select_prob_threshold
+from training.metrics import summary_stats
+from sklearn.metrics import roc_auc_score
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Train base XGBoost classifier with walk-forward CV and probability calibration")
+    ap.add_argument("--data", default="datasets/market_btcusdt_1m_2024_2025.parquet")
+    ap.add_argument("--out", default="models/base_xgb")
+    ap.add_argument("--n-folds", type=int, default=6)
+    ap.add_argument("--embargo-minutes", type=int, default=60)
+    ap.add_argument("--cost-bps", type=float, default=5.0)
+    ap.add_argument("--slippage-bps", type=float, default=0.0)
+    ap.add_argument("--spread-col", default="hl_spread", help="Feature column to use as spread proxy for costs")
+    ap.add_argument("--spread-scale", type=float, default=0.0, help="Scale factor applied to spread_col for additional costs")
+    ap.add_argument("--early-stopping-rounds", type=int, default=50)
+    ap.add_argument("--fold-scheme", choices=["even", "calendar_month"], default="even")
+    args = ap.parse_args(argv)
+
+    df = load_parquet_dataset(args.data)
+    df = ensure_labels(df)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    # Walk-forward evaluation
+    oof_prob = np.zeros(len(df))
+    oof_mask = np.zeros(len(df), dtype=bool)
+    feat_cols_used: List[str] | None = None
+    calib_for_artifact = None
+    model_for_artifact = None
+    last_val_idx = None
+
+    for k, (tr_idx, va_idx) in enumerate(time_folds(df, n_folds=args.n_folds, embargo_minutes=args.embargo_minutes, scheme=args.fold_scheme)):
+        fold = k + 1
+        tr = df.iloc[tr_idx]
+        va = df.iloc[va_idx]
+
+        X_tr, y_tr, feat_cols = extract_features_labels(tr)
+        X_va, y_va, _ = extract_features_labels(va)
+        feat_cols_used = feat_cols
+
+        booster = train_xgb(
+            X_tr, y_tr,
+            X_val=X_va, y_val=y_va,
+            early_stopping_rounds=int(args.early_stopping_rounds),
+        )
+        calib_cv = calibrate(booster, X_va, y_va, method="isotonic")
+        p_va = predict_proba(calib_cv, X_va)
+        oof_prob[va_idx] = p_va
+        oof_mask[va_idx] = True
+
+        # Keep last fold artifacts for saving
+        model_for_artifact = booster
+        calib_for_artifact = calib_cv
+        last_val_idx = va_idx
+
+    # Build threshold and report on OOF predictions
+    valid_idx = np.where(oof_mask)[0]
+    ret_next = df.loc[valid_idx, "ret_next"]
+    p = pd.Series(oof_prob[valid_idx], index=ret_next.index)
+    spread_series = None
+    if args.spread_scale != 0.0 and args.spread_col and args.spread_col in df.columns:
+        spread_series = df.loc[valid_idx, args.spread_col]
+    thr, rep = select_prob_threshold(
+        ret_next,
+        p,
+        cost_bps=args.cost_bps,
+        spread_series=spread_series,
+        spread_scale=args.spread_scale,
+        slippage_bps=args.slippage_bps,
+    )
+
+    # Additional fold-level metrics
+    rep_extra: Dict[str, float] = {"oof_count": int(oof_mask.sum()), "oof_auc": float(roc_auc_score(df.loc[valid_idx, "y_dir"], p.values))}
+    rep.update(rep_extra)
+
+    # Save artifacts
+    out_dir = Path(args.out)
+    save_artifacts(out_dir, model_for_artifact, calib_for_artifact, feat_cols_used or [], float(thr), rep)
+    print(json.dumps({"out_dir": str(out_dir), "threshold": float(thr), "report": rep}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo-data-ingestion/scripts/train_blender.py
+++ b/algo-data-ingestion/scripts/train_blender.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, List
+
+import joblib
+import numpy as np
+import pandas as pd
+import torch
+
+from training.data import load_parquet_dataset, ensure_labels
+from training.model import extract_features_labels
+from training.blender import train_blender, save_blender
+from training.tcn_model import TinyTCN
+
+
+def load_base_predictor(base_dir: Path):
+    # Load prefit calibrator that wraps the XGB classifier
+    calib = joblib.load(base_dir / "calibrator.joblib")
+    feat_cols = json.loads((base_dir / "feature_list.json").read_text())
+    return calib, feat_cols
+
+
+def predict_base(df: pd.DataFrame, calib, feat_cols: List[str]) -> pd.Series:
+    # Align features to training order; missing columns -> 0
+    X = pd.DataFrame(index=df.index)
+    for c in feat_cols:
+        X[c] = df[c].astype(float) if c in df.columns else 0.0
+    p = calib.predict_proba(X.values)[:, 1]
+    return pd.Series(p, index=df.index, name="base_prob")
+
+
+def load_tcn_predictor(tcn_dir: Path):
+    meta = json.loads((tcn_dir / "tcn_meta.json").read_text())
+    pre = joblib.load(tcn_dir / "tcn_preproc.joblib")
+    calib = joblib.load(tcn_dir / "tcn_calibrator.joblib")
+    series_cols = pre["series_cols"]
+    scaler = pre["scaler"]
+    channels = tuple(int(x) for x in meta.get("channels", [32, 32]))
+    kernel_size = int(meta.get("kernel_size", 3))
+    window = int(meta.get("window", 32))
+    model = TinyTCN(n_inputs=len(series_cols), channels=channels, kernel_size=kernel_size)
+    state = torch.load(tcn_dir / "tcn.pt", map_location="cpu")
+    model.load_state_dict(state)
+    model.eval()
+    return model, calib, series_cols, scaler, window
+
+
+def predict_tcn(df: pd.DataFrame, model: TinyTCN, calib, series_cols: List[str], scaler, window: int) -> pd.DataFrame:
+    # Build sliding windows strictly on provided df
+    vals = df[series_cols].astype(float).values
+    if scaler is not None:
+        try:
+            vals = scaler.transform(vals)
+        except Exception:
+            pass
+    n, c = vals.shape
+    L = window
+    N = n - L
+    if N <= 0:
+        return pd.DataFrame(columns=["timestamp", "tcn_prob"])  # not enough data
+    X = np.empty((N, c, L), dtype=np.float32)
+    for i in range(N):
+        seg = vals[i:i+L, :].T
+        m = seg.mean(axis=1, keepdims=True)
+        s = seg.std(axis=1, keepdims=True) + 1e-6
+        seg = (seg - m) / s
+        X[i] = seg
+
+    with torch.no_grad():
+        logits = model(torch.tensor(X, dtype=torch.float32)).view(-1).cpu().numpy()
+    p = calib.predict_proba(logits.reshape(-1, 1))[:, 1]
+    ts = pd.to_datetime(df["timestamp"], utc=True).iloc[L:].reset_index(drop=True)
+    out = pd.DataFrame({"timestamp": ts, "tcn_prob": p})
+    return out
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Train a blender model combining base and TCN predictions with RSS features")
+    ap.add_argument("--data", default="datasets/training_matrix_months_2025-08-09.parquet")
+    ap.add_argument("--base-dir", default="models/base_xgb")
+    ap.add_argument("--tcn-dir", default="models/tcn")
+    ap.add_argument("--out", default="models/blender")
+    ap.add_argument("--cost-bps", type=float, default=5.0)
+    ap.add_argument("--slippage-bps", type=float, default=0.0)
+    ap.add_argument("--spread-col", default="hl_spread")
+    ap.add_argument("--spread-scale", type=float, default=0.0)
+    args = ap.parse_args(argv)
+
+    df = load_parquet_dataset(args.data)
+    df = ensure_labels(df)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    # Base predictions over all rows
+    calib_base, feat_cols = load_base_predictor(Path(args.base_dir))
+    base_prob = predict_base(df, calib_base, feat_cols)
+
+    # TCN predictions (will be shorter due to window)
+    model_tcn, calib_tcn, series_cols, scaler, window = load_tcn_predictor(Path(args.tcn_dir))
+    tcn_df = predict_tcn(df, model_tcn, calib_tcn, series_cols, scaler, window)
+
+    merged = df.copy()
+    merged["base_prob"] = base_prob.values
+    merged = merged.merge(tcn_df, on="timestamp", how="left")
+
+    # Keep rows where both prob and labels exist; drop NA tcn_prob for training blender
+    bset = merged.dropna(subset=["base_prob", "tcn_prob", "y_dir", "ret_next"]).reset_index(drop=True)
+
+    spread_series = None
+    if args.spread_scale != 0.0 and args.spread_col in bset.columns:
+        spread_series = bset[args.spread_col]
+    pipe, thr, rep, cols = train_blender(
+        bset,
+        cost_bps=args.cost_bps,
+        spread_series=spread_series,
+        spread_scale=args.spread_scale,
+        slippage_bps=args.slippage_bps,
+    )
+    out_dir = Path(args.out)
+    save_blender(out_dir, pipe, cols, thr, rep)
+
+    print(json.dumps({"out_dir": str(out_dir), "threshold": float(thr), "report": rep, "features": cols}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo-data-ingestion/scripts/train_meta_label.py
+++ b/algo-data-ingestion/scripts/train_meta_label.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, List
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from training.data import load_parquet_dataset, ensure_labels
+from training.meta import triple_barrier_events, rolling_vol
+from training.thresholds import select_prob_threshold
+from training.model import extract_features_labels
+from training.metrics import equity_curve, summary_stats
+
+from scripts.train_blender import load_base_predictor, predict_base, load_tcn_predictor, predict_tcn
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Train meta-labeling logistic model using triple-barrier events")
+    ap.add_argument("--data", default="datasets/training_matrix_months_2025-08-09.parquet")
+    ap.add_argument("--base-dir", default="models/base_xgb")
+    ap.add_argument("--tcn-dir", default="models/tcn")
+    ap.add_argument("--out", default="models/meta")
+    ap.add_argument("--pt-mult", type=float, default=2.0)
+    ap.add_argument("--sl-mult", type=float, default=2.0)
+    ap.add_argument("--max-hold", type=int, default=60)
+    ap.add_argument("--primary-prob-column", default="base_prob", help="Column to apply masking against (base_prob or tcn_prob or blender_prob if available)")
+    ap.add_argument("--cost-bps", type=float, default=5.0)
+    args = ap.parse_args(argv)
+
+    df = load_parquet_dataset(args.data)
+    df = ensure_labels(df)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    # Base and TCN probabilities
+    calib_base, feat_cols = load_base_predictor(Path(args.base_dir))
+    df["base_prob"] = predict_base(df, calib_base, feat_cols).values
+
+    model_tcn, calib_tcn, series_cols, scaler, window = load_tcn_predictor(Path(args.tcn_dir))
+    tcn_df = predict_tcn(df, model_tcn, calib_tcn, series_cols, scaler, window)
+    df = df.merge(tcn_df, on="timestamp", how="left")
+
+    # Triple barrier labels
+    vol = rolling_vol(np.log(df["close"].astype(float)).diff())
+    events = triple_barrier_events(df["close"], pt_mult=args.pt_mult, sl_mult=args.sl_mult, max_hold=args.max_hold, vol=vol)
+    lab = events["label"].reindex(pd.to_datetime(df["timestamp"], utc=True)).fillna(method="ffill").fillna(0).astype(int)
+
+    # Meta features
+    candidate_cols = [
+        "base_prob", "tcn_prob", "rvol_5", "rvol_20", "rss_count", "rss_sent_mean", "reddit_count", "reddit_sent_mean"
+    ]
+    feat_cols = [c for c in candidate_cols if c in df.columns]
+    X = df[feat_cols].astype(float)
+    y = lab.values
+
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf", LogisticRegression(max_iter=1000, class_weight="balanced")),
+    ])
+    # Drop rows with NA in features
+    mask = X.notna().all(axis=1)
+    Xn = X[mask]
+    yn = y[mask]
+    dn = df.loc[mask].reset_index(drop=True)
+    pipe.fit(Xn.values, yn)
+
+    # Pick meta threshold by maximizing equity when masking primary prob
+    primary = args.primary_prob_column
+    if primary not in dn.columns:
+        raise SystemExit(f"Primary prob column '{primary}' not present after predictions")
+
+    raw_prob = pipe.predict_proba(Xn.values)[:, 1]
+
+    # Evaluate a grid of meta thresholds as mask on the primary prob decisions
+    thr_grid = np.linspace(0.50, 0.90, 9)
+    best = {"meta_threshold": 0.5, "final_equity": -np.inf}
+    for thr_meta in thr_grid:
+        mask_keep = raw_prob >= thr_meta
+        prob_for_trading = dn[primary].values.copy()
+        # mask out low-quality trades by moving prob to neutral 0.5
+        prob_for_trading[~mask_keep] = 0.5
+        eq = equity_curve(dn["ret_next"], pd.Series(prob_for_trading, index=dn.index), threshold=0.6, cost_bps=args.cost_bps)
+        rep = summary_stats(eq)
+        if rep["final_equity"] > best["final_equity"]:
+            best = {**rep, "meta_threshold": float(thr_meta)}
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    joblib.dump(pipe, out_dir / "meta_model.joblib")
+    (out_dir / "features.txt").write_text("\n".join(feat_cols))
+    (out_dir / "meta_threshold.txt").write_text(str(best["meta_threshold"]))
+    (out_dir / "report.json").write_text(json.dumps(best, indent=2))
+    print(json.dumps({"out_dir": str(out_dir), "report": best, "features": feat_cols}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/algo-data-ingestion/scripts/train_tcn.py
+++ b/algo-data-ingestion/scripts/train_tcn.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, List
+
+import numpy as np
+import pandas as pd
+
+from training.data import load_parquet_dataset, ensure_labels, sliding_windows
+from training.walkforward import time_folds
+from training.tcn_model import train_tcn, calibrate_logits, save_tcn, TrainConfig
+from training.thresholds import select_prob_threshold
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Train tiny TCN on sliding windows from market features")
+    ap.add_argument("--data", default="datasets/market_btcusdt_1m_2024_2025.parquet")
+    ap.add_argument("--out", default="models/tcn")
+    ap.add_argument("--window", type=int, default=32)
+    ap.add_argument("--kernel-size", type=int, default=3)
+    ap.add_argument("--channels", default="32,32", help="Comma-separated channels per block, e.g., 32,32")
+    ap.add_argument("--epochs", type=int, default=10)
+    ap.add_argument("--batch-size", type=int, default=256)
+    ap.add_argument("--lr", type=float, default=1e-3)
+    ap.add_argument("--dropout", type=float, default=0.05)
+    ap.add_argument("--n-folds", type=int, default=6)
+    ap.add_argument("--embargo-minutes", type=int, default=60)
+    ap.add_argument("--cost-bps", type=float, default=5.0)
+    ap.add_argument("--slippage-bps", type=float, default=0.0)
+    ap.add_argument("--spread-col", default="hl_spread")
+    ap.add_argument("--spread-scale", type=float, default=0.0)
+    ap.add_argument("--fold-scheme", choices=["even", "calendar_month"], default="even")
+    args = ap.parse_args(argv)
+
+    df = load_parquet_dataset(args.data)
+    df = ensure_labels(df)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    # Build windows aligned to df
+    X, y, ts, series_cols, scaler = sliding_windows(df, window=args.window)
+    win_df = pd.DataFrame({
+        "timestamp": ts,
+        "y_dir": y,
+        "ret_next": df.loc[df.index[-len(ts):], "ret_next"].reset_index(drop=True),
+    })
+
+    # OOF evaluation
+    logits_oof = np.zeros(len(win_df))
+    mask_oof = np.zeros(len(win_df), dtype=bool)
+    calib_for_artifact = None
+    model_for_artifact = None
+
+    channels = tuple(int(x) for x in args.channels.split(",") if x.strip())
+    tcfg = TrainConfig(epochs=args.epochs, lr=args.lr, batch_size=args.batch_size)
+
+    for k, (tr_idx, va_idx) in enumerate(time_folds(win_df, n_folds=args.n_folds, embargo_minutes=args.embargo_minutes, scheme=args.fold_scheme)):
+        fold = k + 1
+        X_tr, y_tr = X[tr_idx], y[tr_idx]
+        X_va, y_va = X[va_idx], y[va_idx]
+
+        model, logits_tr, logits_va = train_tcn(
+            X_tr, y_tr,
+            val=(X_va, y_va),
+            kernel_size=args.kernel_size,
+            channels=channels,
+            dropout=args.dropout,
+            config=tcfg,
+        )
+        calib = calibrate_logits(logits_va, y_va, method="isotonic")
+        p_va = calib.predict_proba(logits_va.reshape(-1, 1))[:, 1]
+        logits_oof[va_idx] = p_va
+        mask_oof[va_idx] = True
+
+        model_for_artifact = model
+        calib_for_artifact = calib
+
+    # Enrich win_df with spread column aligned to window ends (if it exists in df)
+    if args.spread_col and args.spread_col in df.columns:
+        win_df[args.spread_col] = df.loc[df.index[-len(ts):], args.spread_col].reset_index(drop=True)
+
+    valid_idx = np.where(mask_oof)[0]
+    spread_series = None
+    if args.spread_scale != 0.0 and args.spread_col in win_df.columns:
+        spread_series = win_df.loc[valid_idx, args.spread_col]
+    thr, rep = select_prob_threshold(
+        win_df.loc[valid_idx, "ret_next"],
+        pd.Series(logits_oof[valid_idx], index=valid_idx),
+        cost_bps=args.cost_bps,
+        spread_series=spread_series,
+        spread_scale=args.spread_scale,
+        slippage_bps=args.slippage_bps,
+    )
+    rep.update({"oof_count": int(mask_oof.sum())})
+
+    out_dir = Path(args.out)
+    save_tcn(out_dir, model_for_artifact, scaler, calib_for_artifact, series_cols, meta={
+        "window": int(args.window),
+        "kernel_size": int(args.kernel_size),
+        "channels": [int(x) for x in channels],
+        "dropout": float(args.dropout),
+    })
+    (out_dir / "threshold.json").write_text(json.dumps({"prob_threshold": float(thr)}))
+    (out_dir / "report.json").write_text(json.dumps(rep, indent=2))
+
+    print(json.dumps({"out_dir": str(out_dir), "threshold": float(thr), "report": rep}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/algo-data-ingestion/training/blender.py
+++ b/algo-data-ingestion/training/blender.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Tuple, Dict, Optional
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
+
+from .thresholds import select_prob_threshold
+
+
+BLENDER_NON_FEAT = {"timestamp", "y_dir", "ret_next", "dt", "symbol", "exchange", "timeframe", "feature_version", "close"}
+
+
+def build_blender_features(df: pd.DataFrame, *, candidate_cols: List[str] | None = None) -> Tuple[pd.DataFrame, List[str]]:
+    if candidate_cols is None:
+        candidate_cols = [
+            "base_prob", "tcn_prob",
+            "rss_count", "rss_sent_mean",
+            "reddit_count", "reddit_sent_mean",
+            "rvol_5", "rvol_20",
+        ]
+    cols = [c for c in candidate_cols if c in df.columns]
+    if not cols:
+        raise ValueError("No blender feature columns found. Provide candidate_cols or ensure columns exist.")
+    X = df[cols].astype(float)
+    return X, cols
+
+
+def train_blender(
+    df: pd.DataFrame,
+    *,
+    cost_bps: float = 5.0,
+    spread_series: Optional[pd.Series] = None,
+    spread_scale: float = 0.0,
+    slippage_bps: float = 0.0,
+) -> Tuple[Pipeline, float, Dict, List[str]]:
+    X, cols = build_blender_features(df)
+    y = df["y_dir"].astype(int)
+    # Simple logistic with scaling
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("clf", LogisticRegression(max_iter=1000, class_weight="balanced")),
+    ])
+    pipe.fit(X.values, y.values)
+    prob = pipe.predict_proba(X.values)[:, 1]
+    thr, rep = select_prob_threshold(
+        df["ret_next"],
+        pd.Series(prob, index=df.index),
+        cost_bps=cost_bps,
+        spread_series=spread_series,
+        spread_scale=spread_scale,
+        slippage_bps=slippage_bps,
+    )
+    return pipe, thr, rep, cols
+
+
+def save_blender(out_dir: Path, model: Pipeline, feat_cols: List[str], threshold: float, report: Dict) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, out_dir / "blender.joblib")
+    (out_dir / "blender_features.txt").write_text("\n".join(feat_cols))
+    (out_dir / "threshold.txt").write_text(str(float(threshold)))
+    (out_dir / "report.json").write_text(__import__("json").dumps(report, indent=2))

--- a/algo-data-ingestion/training/data.py
+++ b/algo-data-ingestion/training/data.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Tuple, Optional, Sequence, Dict
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+
+def load_parquet_dataset(path: str | Path, *, drop_duplicates: bool = True) -> pd.DataFrame:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Dataset not found: {p}")
+    df = pd.read_parquet(p)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        if drop_duplicates:
+            df = df.sort_values("timestamp").drop_duplicates(subset=["timestamp"], keep="last")
+    return df.reset_index(drop=True)
+
+
+def sliding_windows(
+    df: pd.DataFrame,
+    *,
+    window: int = 32,
+    series_cols: Optional[Sequence[str]] = None,
+    y_col: str = "y_dir",
+    standardize_per_window: bool = True,
+) -> Tuple[np.ndarray, np.ndarray, pd.Series, List[str], StandardScaler | None]:
+    """
+    Build a 3D tensor (N, C, L) for TCN/CNN models from sequential features.
+    Returns (X, y, ts, used_cols, scaler)
+    - X: float32 array, shape (N, C, L)
+    - y: int64 array, shape (N,)
+    - ts: timestamps for the window end row
+    - used_cols: the feature channels used
+    - scaler: optional StandardScaler applied across dataset channels
+    """
+    if series_cols is None:
+        # Default to market micro-structure oriented channels
+        # Assumes dataset built via `build_market_features`
+        default_cols = [
+            "ret_1", "logret_1", "rvol_5", "rvol_20", "macd", "macd_signal_9", "rsi_14", "hl_spread", "oi_obv",
+        ]
+        series_cols = [c for c in default_cols if c in df.columns]
+        if not series_cols:
+            raise ValueError("No suitable series columns found in dataset for TCN windows")
+
+    vals = df[series_cols].astype(float).values
+    y = df[y_col].astype(int).values if y_col in df.columns else None
+    ts = pd.to_datetime(df["timestamp"], utc=True) if "timestamp" in df.columns else pd.Series(index=df.index, data=pd.NaT)
+
+    # Global scaler across channels (fit on in-sample portion externally if needed)
+    scaler: Optional[StandardScaler] = None
+    try:
+        scaler = StandardScaler(with_mean=True, with_std=True)
+        vals = scaler.fit_transform(vals)
+    except Exception:
+        scaler = None
+
+    n, c = vals.shape
+    if n < window + 1:
+        raise ValueError(f"Not enough rows for window={window}")
+
+    # Build windows with stride 1
+    L = window
+    N = n - L
+    X = np.empty((N, c, L), dtype=np.float32)
+    for i in range(N):
+        seg = vals[i:i+L, :].T  # (C, L)
+        if standardize_per_window:
+            # Per-window standardization for stability (channel-wise)
+            m = seg.mean(axis=1, keepdims=True)
+            s = seg.std(axis=1, keepdims=True) + 1e-6
+            seg = (seg - m) / s
+        X[i] = seg
+
+    y_out = y[L:] if y is not None else np.array([], dtype=np.int64)
+    ts_out = ts.iloc[L:] if len(ts) else pd.Series(dtype="datetime64[ns, UTC]")
+    return X, y_out.astype(np.int64), ts_out.reset_index(drop=True), list(series_cols), scaler
+
+
+def select_market_features(df: pd.DataFrame, *, exclude: Optional[Sequence[str]] = None) -> Tuple[pd.DataFrame, pd.Series, List[str]]:
+    """
+    Extract tabular features for tree models, dropping non-feature columns.
+    """
+    non_feat = {"timestamp", "dt", "symbol", "exchange", "timeframe", "feature_version", "close", "ret_next", "y_dir"}
+    if exclude:
+        non_feat |= set(exclude)
+    feat_cols = [c for c in df.columns if c not in non_feat]
+    X = df[feat_cols].astype(float)
+    y = df["y_dir"].astype(int) if "y_dir" in df.columns else pd.Series(index=df.index, dtype=int)
+    return X, y, feat_cols
+
+
+def ensure_labels(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    if "ret_next" not in out.columns and "close" in out.columns:
+        out["ret_next"] = out["close"].pct_change().shift(-1)
+    if "y_dir" not in out.columns and "ret_next" in out.columns:
+        out["y_dir"] = (out["ret_next"] > 0).astype(int)
+    if "timestamp" in out.columns:
+        out = out.iloc[:-1].copy()  # drop last unlabeled row
+    return out
+

--- a/algo-data-ingestion/training/meta.py
+++ b/algo-data-ingestion/training/meta.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+from typing import Tuple, Dict, Optional
+
+import numpy as np
+import pandas as pd
+
+
+def rolling_vol(logret: pd.Series, window: int = 50) -> pd.Series:
+    return logret.rolling(window, min_periods=window//2).std().fillna(method="bfill")
+
+
+def triple_barrier_events(
+    close: pd.Series,
+    *,
+    pt_mult: float = 2.0,
+    sl_mult: float = 2.0,
+    max_hold: int = 60,
+    vol: Optional[pd.Series] = None,
+    pt_pct: Optional[float] = None,
+    sl_pct: Optional[float] = None,
+) -> pd.DataFrame:
+    """
+    Generate triple-barrier events. Uses relative returns on close.
+    - pt/sl are applied to cumulative return threshold derived from volatility.
+    - max_hold is time barrier in bars.
+    Returns DataFrame with columns: t_end, ret, label (1 success, 0 fail)
+    """
+    c = close.astype(float).values
+    ts = pd.to_datetime(close.index if isinstance(close.index, pd.DatetimeIndex) else pd.to_datetime(close.index, unit='s'), utc=True, errors='ignore')
+    if not isinstance(ts, pd.DatetimeIndex):
+        # fallback to sequential index if timestamps not provided
+        ts = pd.DatetimeIndex(pd.to_datetime(np.arange(len(c)), unit='s'))
+
+    logret = np.diff(np.log(np.clip(c, 1e-12, None)), prepend=np.log(np.clip(c[0],1e-12,None)))
+    if vol is None:
+        # Percent-based PT/SL when vol not provided
+        vol = None
+        use_percent = True
+        pt_pct = float(pt_pct) if pt_pct is not None else 0.005  # 50 bps default
+        sl_pct = float(sl_pct) if sl_pct is not None else 0.005
+    else:
+        vol = vol.reindex(ts).fillna(method="bfill").fillna(method="ffill")
+        use_percent = False
+
+    n = len(c)
+    t_end = np.empty(n, dtype=object)
+    meta_ret = np.zeros(n, dtype=np.float64)
+    label = np.zeros(n, dtype=np.int64)
+
+    for i in range(n):
+        # dynamic thresholds based on local vol
+        if use_percent:
+            pt = pt_pct
+            sl = sl_pct
+        else:
+            v = float(vol.iloc[i]) if i < len(vol) else float(np.nan)
+            if not np.isfinite(v) or v <= 0:
+                v = float(np.nanmean(vol.values)) if np.isfinite(np.nanmean(vol.values)) else 1e-3
+            pt = pt_mult * v
+            sl = sl_mult * v
+        base = c[i]
+        j_max = min(n - 1, i + max_hold)
+        outcome = 0
+        ret_end = 0.0
+        j_hit = i
+        for j in range(i + 1, j_max + 1):
+            rr = (c[j] - base) / base
+            if rr >= pt:
+                outcome = 1
+                ret_end = rr
+                j_hit = j
+                break
+            if rr <= -sl:
+                outcome = 0
+                ret_end = rr
+                j_hit = j
+                break
+            # time barrier if reaches j_max without hit
+            if j == j_max:
+                outcome = 1 if rr > 0 else 0
+                ret_end = rr
+                j_hit = j
+        t_end[i] = ts[j_hit]
+        meta_ret[i] = ret_end
+        label[i] = outcome
+
+    return pd.DataFrame({
+        "t_end": pd.to_datetime(t_end, utc=True),
+        "ret": meta_ret,
+        "label": label,
+    }, index=ts)

--- a/algo-data-ingestion/training/metrics.py
+++ b/algo-data-ingestion/training/metrics.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+from typing import Dict, Optional
+
+
+def equity_curve(
+    ret_next: pd.Series,
+    prob: pd.Series,
+    threshold: float,
+    cost_bps: float = 5.0,
+    *,
+    spread_series: Optional[pd.Series] = None,
+    spread_scale: float = 0.0,
+    slippage_bps: float = 0.0,
+) -> pd.DataFrame:
+    """
+    Simple thresholded strategy:
+      - position at t is decided with prob at t-1 (one-bar lag)
+      - pos ∈ {-1,0,1}; apply symmetric threshold around 0.5
+      - PnL_t = pos_{t-1} * ret_next_t - cost_bps * turnover_t
+    """
+    proba = prob.astype(float).values
+    ret = ret_next.astype(float).values
+    thr = float(threshold)
+
+    pos = np.zeros_like(proba)
+    pos[proba >= thr] = 1
+    pos[proba <= 1.0 - thr] = -1
+
+    pos_lag = np.roll(pos, 1)
+    pos_lag[0] = 0
+    turnover = np.abs(pos - pos_lag)
+    # Base costs in returns terms
+    base_cost = ((cost_bps + slippage_bps) / 1e4) * turnover
+    spread_cost = 0.0
+    if spread_series is not None and spread_scale != 0.0:
+        try:
+            ss = spread_series.astype(float).values
+            # Align length by padding or trimming
+            if len(ss) != len(turnover):
+                if len(ss) > len(turnover):
+                    ss = ss[-len(turnover):]
+                else:
+                    pad = np.full(len(turnover) - len(ss), ss[-1] if len(ss) else 0.0)
+                    ss = np.concatenate([ss, pad])
+            spread_cost = spread_scale * ss * turnover
+        except Exception:
+            spread_cost = 0.0
+    cost = base_cost + spread_cost
+
+    pnl = pos_lag * ret - cost
+    eq = np.cumprod(1.0 + pnl)
+
+    return pd.DataFrame({
+        "pos": pos,
+        "pos_lag": pos_lag,
+        "turnover": turnover,
+        "pnl": pnl,
+        "equity": eq,
+    })
+
+
+def summary_stats(df: pd.DataFrame) -> Dict[str, float]:
+    pnl = df["pnl"].values
+    eq = df["equity"].values
+    ret = pnl
+    mean = float(np.mean(ret))
+    std = float(np.std(ret) + 1e-12)
+    sharpe = mean / std * np.sqrt(252*24*60)  # rough annualization for 1m
+    max_dd = float(np.max(np.maximum.accumulate(eq) - eq))
+    return {
+        "mean_pnl": mean,
+        "std_pnl": std,
+        "sharpe": sharpe,
+        "max_drawdown": max_dd,
+        "final_equity": float(eq[-1]) if len(eq) else 1.0,
+        "avg_turnover": float(np.mean(df["turnover"])) if "turnover" in df.columns else 0.0,
+        "total_turnover": float(np.sum(df["turnover"])) if "turnover" in df.columns else 0.0,
+    }

--- a/algo-data-ingestion/training/model.py
+++ b/algo-data-ingestion/training/model.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+import xgboost as xgb
+
+
+NON_FEAT = {"timestamp","dt","symbol","exchange","timeframe","feature_version","close","ret_next","y_dir"}
+
+
+def extract_features_labels(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series, List[str]]:
+    y = df["y_dir"].astype(int)
+    feat_cols = [c for c in df.columns if c not in NON_FEAT]
+    X = df[feat_cols].astype(float)
+    return X, y, feat_cols
+
+
+def train_xgb(
+    X: pd.DataFrame,
+    y: pd.Series,
+    params: Optional[Dict] = None,
+    *,
+    X_val: Optional[pd.DataFrame] = None,
+    y_val: Optional[pd.Series] = None,
+    early_stopping_rounds: int = 50,
+) -> xgb.XGBClassifier:
+    if params is None:
+        params = {
+            "n_estimators": 500,
+            "max_depth": 5,
+            "learning_rate": 0.05,
+            "subsample": 0.8,
+            "colsample_bytree": 0.8,
+            "objective": "binary:logistic",
+            "tree_method": "hist",
+            "eval_metric": "logloss",
+        }
+    model = xgb.XGBClassifier(**params)
+    if X_val is not None and y_val is not None and len(X_val) > 0:
+        model.fit(
+            X.values, y.values,
+            eval_set=[(X_val.values, y_val.values)],
+            verbose=False,
+            early_stopping_rounds=early_stopping_rounds,
+        )
+    else:
+        model.fit(X.values, y.values)
+    return model
+
+
+def calibrate(model: xgb.XGBClassifier, X_val: pd.DataFrame, y_val: pd.Series, method: str = "isotonic") -> CalibratedClassifierCV:
+    calib = CalibratedClassifierCV(model, method=method, cv="prefit")
+    calib.fit(X_val.values, y_val.values)
+    return calib
+
+
+def predict_proba(model_or_calib, X: pd.DataFrame) -> np.ndarray:
+    p = model_or_calib.predict_proba(X.values)[:,1]
+    return p
+
+
+def save_artifacts(out_dir: Path, booster: xgb.XGBClassifier, calib: CalibratedClassifierCV, feat_cols: List[str], threshold: float, report: Dict) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    booster.get_booster().save_model(str(out_dir/"model.json"))
+    joblib.dump(calib, out_dir/"calibrator.joblib")
+    (out_dir/"feature_list.json").write_text(json.dumps(feat_cols))
+    (out_dir/"threshold.json").write_text(json.dumps({"prob_threshold": threshold}))
+    (out_dir/"report.json").write_text(json.dumps(report, indent=2))

--- a/algo-data-ingestion/training/tcn_model.py
+++ b/algo-data-ingestion/training/tcn_model.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple, Dict, Optional
+
+import joblib
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.linear_model import LogisticRegression
+
+
+class Chomp1d(nn.Module):
+    def __init__(self, chomp_size: int):
+        super().__init__()
+        self.chomp_size = chomp_size
+
+    def forward(self, x):
+        return x[:, :, :-self.chomp_size]
+
+
+class TemporalBlock(nn.Module):
+    def __init__(self, n_inputs, n_outputs, kernel_size, stride, dilation, padding, dropout=0.0):
+        super().__init__()
+        self.conv1 = nn.Conv1d(n_inputs, n_outputs, kernel_size, stride=stride, padding=padding, dilation=dilation)
+        self.chomp1 = Chomp1d(padding)
+        self.relu1 = nn.ReLU()
+        self.drop1 = nn.Dropout(dropout)
+
+        self.conv2 = nn.Conv1d(n_outputs, n_outputs, kernel_size, stride=stride, padding=padding, dilation=dilation)
+        self.chomp2 = Chomp1d(padding)
+        self.relu2 = nn.ReLU()
+        self.drop2 = nn.Dropout(dropout)
+
+        self.downsample = nn.Conv1d(n_inputs, n_outputs, 1) if n_inputs != n_outputs else None
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.chomp1(out)
+        out = self.relu1(out)
+        out = self.drop1(out)
+
+        out = self.conv2(out)
+        out = self.chomp2(out)
+        out = self.relu2(out)
+        out = self.drop2(out)
+
+        res = x if self.downsample is None else self.downsample(x)
+        return self.relu(out + res)
+
+
+class TinyTCN(nn.Module):
+    def __init__(self, n_inputs: int, channels: Tuple[int, int] = (32, 32), kernel_size: int = 3, dropout: float = 0.0):
+        super().__init__()
+        layers = []
+        in_ch = n_inputs
+        dilation = 1
+        for out_ch in channels:
+            padding = (kernel_size - 1) * dilation
+            layers += [TemporalBlock(in_ch, out_ch, kernel_size, stride=1, dilation=dilation, padding=padding, dropout=dropout)]
+            in_ch = out_ch
+            dilation *= 2
+        self.network = nn.Sequential(*layers)
+        self.pool = nn.AdaptiveAvgPool1d(1)
+        self.head = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(in_ch, max(16, in_ch // 2)),
+            nn.ReLU(),
+            nn.Linear(max(16, in_ch // 2), 1),
+        )
+
+    def forward(self, x):
+        # x: (B, C, L)
+        h = self.network(x)
+        h = self.pool(h)
+        logits = self.head(h).squeeze(-1)
+        return logits
+
+
+@dataclass
+class TrainConfig:
+    epochs: int = 10
+    lr: float = 1e-3
+    weight_decay: float = 1e-4
+    batch_size: int = 256
+    class_weight: Optional[float] = None  # weight for positive class
+
+
+def train_tcn(
+    X: np.ndarray,
+    y: np.ndarray,
+    *,
+    val: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+    kernel_size: int = 3,
+    channels: Tuple[int, int] = (32, 32),
+    dropout: float = 0.05,
+    config: TrainConfig = TrainConfig(),
+    device: Optional[str] = None,
+) -> Tuple[TinyTCN, np.ndarray, Optional[np.ndarray]]:
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    model = TinyTCN(X.shape[1], channels=channels, kernel_size=kernel_size, dropout=dropout).to(device)
+    opt = optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+    pos_weight = None
+    if config.class_weight is not None:
+        # BCEWithLogitsLoss supports pos_weight tensor
+        pos_weight = torch.tensor([float(config.class_weight)], device=device)
+    loss_fn = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
+
+    def _iter_batches(Xa, ya):
+        n = len(ya)
+        bs = config.batch_size
+        idx = np.arange(n)
+        for i in range(0, n, bs):
+            j = min(n, i + bs)
+            xb = torch.tensor(Xa[i:j], dtype=torch.float32, device=device)
+            yb = torch.tensor(ya[i:j], dtype=torch.float32, device=device)
+            yield xb, yb
+
+    model.train()
+    for epoch in range(config.epochs):
+        perm = np.random.permutation(len(y))
+        Xp, yp = X[perm], y[perm]
+        total = 0.0
+        for xb, yb in _iter_batches(Xp, yp):
+            opt.zero_grad()
+            logits = model(xb).view(-1)
+            loss = loss_fn(logits, yb)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            opt.step()
+            total += float(loss.detach().cpu().item()) * len(yb)
+        # optional early-stopping by val loss could be added here
+        _ = total / max(1, len(y))
+
+    model.eval()
+    with torch.no_grad():
+        logits_train = model(torch.tensor(X, dtype=torch.float32, device=device)).view(-1).cpu().numpy()
+        logits_val = None
+        if val is not None:
+            Xv, yv = val
+            logits_val = model(torch.tensor(Xv, dtype=torch.float32, device=device)).view(-1).cpu().numpy()
+    return model, logits_train, logits_val
+
+
+def calibrate_logits(logits: np.ndarray, y: np.ndarray, method: str = "isotonic") -> CalibratedClassifierCV:
+    # Use a simple LR with calibrator by wrapping logits as a single-feature input
+    # Fit a dummy LR first then calibrate with preferred method
+    base = LogisticRegression(max_iter=1000)
+    z = logits.reshape(-1, 1)
+    base.fit(z, y)
+    calib = CalibratedClassifierCV(base, method=method, cv="prefit")
+    calib.fit(z, y)
+    return calib
+
+
+def save_tcn(out_dir: Path, model: TinyTCN, scaler, calib: Optional[CalibratedClassifierCV], used_cols, meta: Optional[dict] = None):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Torch model
+    torch.save(model.state_dict(), out_dir / "tcn.pt")
+    # Feature scaler + calibrator + series columns
+    joblib.dump({"scaler": scaler, "series_cols": used_cols}, out_dir / "tcn_preproc.joblib")
+    if calib is not None:
+        joblib.dump(calib, out_dir / "tcn_calibrator.joblib")
+    if meta is not None:
+        (out_dir / "tcn_meta.json").write_text(__import__("json").dumps(meta, indent=2))

--- a/algo-data-ingestion/training/thresholds.py
+++ b/algo-data-ingestion/training/thresholds.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from typing import Dict, Tuple, Optional
+
+import numpy as np
+import pandas as pd
+
+from .metrics import equity_curve, summary_stats
+
+
+def select_prob_threshold(
+    ret_next: pd.Series,
+    prob: pd.Series,
+    *,
+    cost_bps: float = 5.0,
+    grid: Optional[np.ndarray] = None,
+    criterion: str = "final_equity",
+    spread_series: Optional[pd.Series] = None,
+    spread_scale: float = 0.0,
+    slippage_bps: float = 0.0,
+) -> Tuple[float, Dict]:
+    """
+    Search probability threshold p* maximizing PnL/Sharpe on provided series.
+
+    - Symmetric long/short: long if p>=p*, short if p<=1-p*.
+    - `criterion` in {"final_equity", "sharpe"}.
+    """
+    if grid is None:
+        grid = np.linspace(0.55, 0.80, 14)
+
+    best_thr = float(grid[0])
+    best_val = -np.inf
+    best_report = {}
+
+    for thr in grid:
+        eq = equity_curve(
+            ret_next,
+            prob,
+            threshold=float(thr),
+            cost_bps=cost_bps,
+            spread_series=spread_series,
+            spread_scale=spread_scale,
+            slippage_bps=slippage_bps,
+        )
+        rep = summary_stats(eq)
+        val = rep["final_equity"] if criterion == "final_equity" else rep["sharpe"]
+        if val > best_val:
+            best_val = val
+            best_thr = float(thr)
+            best_report = rep
+
+    best_report = dict(best_report)
+    best_report.update({
+        "selected_threshold": best_thr,
+        "criterion": criterion,
+        "cost_bps": float(cost_bps),
+        "spread_scale": float(spread_scale),
+        "slippage_bps": float(slippage_bps),
+    })
+    return best_thr, best_report

--- a/algo-data-ingestion/training/walkforward.py
+++ b/algo-data-ingestion/training/walkforward.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+import pandas as pd
+from typing import Iterator, Tuple
+
+
+def time_folds(
+    df: pd.DataFrame,
+    n_folds: int = 6,
+    embargo_minutes: int = 60,
+    *,
+    scheme: str = "even",
+) -> Iterator[Tuple[pd.Index, pd.Index]]:
+    """
+    Yield (train_idx, val_idx) pairs for time-ordered walk-forward folds.
+    Embargo removes a gap around fold boundaries to avoid leakage.
+    """
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    ts = pd.to_datetime(df["timestamp"], utc=True)
+    n = len(df)
+
+    if scheme == "calendar_month":
+        months = ts.dt.to_period("M").astype(str)
+        df = df.assign(_month=months)
+        unique_months = list(dict.fromkeys(df["_month"].tolist()))  # preserve order
+        # Use last n_folds months as validation folds if specified; otherwise all but the first
+        start_idx = max(1, len(unique_months) - n_folds) if n_folds is not None else 1
+        months_for_val = unique_months[start_idx:]
+        for m in months_for_val:
+            val_mask = df["_month"] == m
+            if not val_mask.any():
+                continue
+            val_idx = df.index[val_mask]
+            val_start = int(val_idx.min())
+            val_end = int(val_idx.max()) + 1  # exclusive end
+            if embargo_minutes > 0:
+                emb_bars = embargo_minutes
+                emb_start = max(0, val_start - emb_bars)
+                emb_end = min(n, val_end + emb_bars)
+                train_mask = (df.index < emb_start) | (df.index >= emb_end)
+            else:
+                train_mask = ~val_mask
+            yield (df.index[train_mask], df.index[val_mask])
+    else:
+        # Default: even-sized folds over index
+        fold_size = n // (n_folds + 1)
+        for k in range(1, n_folds + 1):
+            val_start = k * fold_size
+            val_end = (k + 1) * fold_size if k < n_folds else n
+            val_mask = (df.index >= val_start) & (df.index < val_end)
+
+            if embargo_minutes > 0:
+                emb_bars = embargo_minutes  # 1 bar ~ 1 minute
+                emb_start = max(0, val_start - emb_bars)
+                emb_end = min(n, val_end + emb_bars)
+                train_mask = (df.index < emb_start) | (df.index >= emb_end)
+            else:
+                train_mask = ~val_mask
+
+            yield (df.index[train_mask], df.index[val_mask])


### PR DESCRIPTION
feat(ml): end-to-end training stack (XGB, TCN, blender, meta) + calibration, cost-aware thresholds, month folds

Summary
- Add production-ready ML stack: base XGBoost, Tiny TCN, blender, and meta-label pipeline.
- Probability calibration (isotonic/Platt), cost-aware threshold selection, and calendar-month walk-forward folds.
New Training Utilities
- training/data.py: parquet loader, label assurance, sliding-window builder.
- training/thresholds.py: PnL/Sharpe-driven threshold selection with spread/slippage.
- training/meta.py: triple-barrier events (vol- or percent-based).
- training/metrics.py: equity curve with turnover, spread and slippage costs; summary stats.
- training/model.py: XGBoost training with early stopping and calibrator.
- training/tcn_model.py: Tiny TCN + training loop and calibration.
- training/walkforward.py: even and calendar-month fold schemes with embargo.
New CLI Scripts
- scripts/train_base_gbdt.py: walk-forward XGB + isotonic calibration; threshold via costs.
- scripts/train_tcn.py: TCN on sliding windows; calibrated logits; threshold via costs.
- scripts/train_blender.py: stack base + TCN + RSS/regime features; logistic blender + threshold.
- scripts/train_meta_label.py: meta-label via triple-barrier; masks primary probs.
Cost Model & Flags
1) --cost-bps, --slippage-bps, --spread-col, --spread-scale for threshold selection.
Folds
1) --fold-scheme {even,calendar_month} used in base/TCN scripts.
Docs

IMPLEMENT_WITH_YOUR_DATASETS.md walkthrough for dataset-driven implementation.
Notes

Large artifacts (.parquet, .ipynb) remain untracked; core ML code and scripts are included.