### PR TITLE
fix(trading): authenticate Redis decision messages

### DIFF
--- a/algo-data-ingestion/.env.example
+++ b/algo-data-ingestion/.env.example
@@ -92,3 +92,7 @@ SOCIAL_SENTIMENT_ENRICH=0
 # GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp-sa.json
 # DATA_LAKE_PATH=gs://my-bucket/algo-data-lake
 # MARKET_PATH=gs://my-bucket/algo-data-lake/market
+# Shared HMAC secret used by the scheduler to sign trading decisions and by
+# the trading worker to reject forged Redis queue messages. Generate a strong
+# random value before enabling the compose stack or live trading.
+TRADING_DECISION_HMAC_SECRET=

--- a/algo-data-ingestion/app/decision_auth.py
+++ b/algo-data-ingestion/app/decision_auth.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+SIGNATURE_ALGORITHM = "HMAC-SHA256"
+SIGNATURE_FIELD = "decision_signature"
+SIGNATURE_ALGORITHM_FIELD = "decision_signature_algorithm"
+_SIGNED_PAYLOAD_FIELDS = (SIGNATURE_FIELD, SIGNATURE_ALGORITHM_FIELD)
+
+
+def _clean_secret(secret: Optional[str]) -> Optional[str]:
+    if secret is None:
+        return None
+    value = str(secret).strip()
+    return value or None
+
+
+def _unsigned_payload(message: Mapping[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in message.items() if key not in _SIGNED_PAYLOAD_FIELDS}
+
+
+def canonical_decision_payload(message: Mapping[str, Any]) -> bytes:
+    """
+    Serialize a decision message deterministically for HMAC signing.
+
+    The signature metadata fields are excluded so the same helper can be used for
+    both initial signing and later verification.
+    """
+    return json.dumps(
+        _unsigned_payload(message),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+
+def sign_decision_message(message: Mapping[str, Any], secret: Optional[str]) -> Dict[str, Any]:
+    """Return a signed copy of *message* when a decision HMAC secret is configured."""
+    signed = dict(message)
+    secret_value = _clean_secret(secret)
+    if not secret_value:
+        return signed
+    digest = hmac.new(
+        secret_value.encode("utf-8"),
+        canonical_decision_payload(signed),
+        hashlib.sha256,
+    ).hexdigest()
+    signed[SIGNATURE_ALGORITHM_FIELD] = SIGNATURE_ALGORITHM
+    signed[SIGNATURE_FIELD] = digest
+    return signed
+
+
+def verify_decision_message(message: Mapping[str, Any], secret: Optional[str]) -> Tuple[bool, str]:
+    """Verify a signed decision message.
+
+    Returns (True, "ok") when verification succeeds. If no secret is configured,
+    messages are accepted for dry-run/demo compatibility and the caller is
+    expected to prohibit live trading without a secret.
+    """
+    secret_value = _clean_secret(secret)
+    if not secret_value:
+        return True, "decision_hmac_not_configured"
+    if message.get(SIGNATURE_ALGORITHM_FIELD) != SIGNATURE_ALGORITHM:
+        return False, "missing_or_unsupported_decision_signature_algorithm"
+    supplied = message.get(SIGNATURE_FIELD)
+    if not isinstance(supplied, str) or not supplied.strip():
+        return False, "missing_decision_signature"
+    expected = hmac.new(
+        secret_value.encode("utf-8"),
+        canonical_decision_payload(message),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(supplied.strip(), expected):
+        return False, "invalid_decision_signature"
+    return True, "ok"

--- a/algo-data-ingestion/app/scheduler/main.py
+++ b/algo-data-ingestion/app/scheduler/main.py
@@ -56,6 +56,7 @@ from training.calibration_store import load_calibrator, LoadedCalibrator
 from training.calibration_utils import apply_posthoc_calibration
 from app.monitoring.model_metrics import observe_gate_coverage, record_gate_coverage_sample
 from app.monitoring.probability_sampler import record_probability_samples
+from app.decision_auth import sign_decision_message
 from collections import defaultdict
 from features.feature_engineering import FEATURE_REGISTRY
 
@@ -129,6 +130,7 @@ MODELS_ROOT: Path = Path(os.getenv("MODELS_ROOT", "models")).expanduser().resolv
 DATA_LAKE_ROOT: Path = Path(os.getenv("DATA_LAKE_ROOT", "/app/data_lake/market")).expanduser().resolve()
 DECISION_QUEUE_URL: str = os.getenv("DECISION_QUEUE_URL") or os.getenv("REDIS_URL", "redis://redis:6379/0")
 DECISION_QUEUE_KEY: str = os.getenv("DECISION_QUEUE_KEY", "trading:decisions")
+DECISION_HMAC_SECRET: Optional[str] = (os.getenv("TRADING_DECISION_HMAC_SECRET") or "").strip() or None
 DEFAULT_DECISION_PAYLOAD_ITEMS: int = max(1, int(os.getenv("DECISION_PAYLOAD_ITEMS", "3")))
 DEFAULT_INFER_STRIDE: int = max(1, int(os.getenv("INFER_DEFAULT_STRIDE", "30")))
 DEFAULT_HISTORY_MARGIN_MIN: int = max(0, int(os.getenv("INFER_HISTORY_MARGIN_MIN", "120")))
@@ -699,7 +701,7 @@ async def _enqueue_payload(job: InferenceJob, payload: Dict[str, Any], now: date
             message["policy_contract"] = policy_contract
         if job.include_features and "features" in item:
             message["features"] = item["features"]
-        messages.append(json.dumps(message, default=str))
+        messages.append(json.dumps(sign_decision_message(message, DECISION_HMAC_SECRET), default=str))
 
     if not messages:
         log.info(

--- a/algo-data-ingestion/app/trading/config.py
+++ b/algo-data-ingestion/app/trading/config.py
@@ -84,6 +84,7 @@ class TradingModelConfig(BaseModel):
 class TradingConfig(BaseSettings):
     decision_queue_url: str = Field("redis://localhost:6379/0", alias="DECISION_QUEUE_URL")
     decision_queue_key: str = Field("trading:decisions", alias="DECISION_QUEUE_KEY")
+    decision_hmac_secret: Optional[str] = Field(None, alias="TRADING_DECISION_HMAC_SECRET")
     last_timestamp_hash: str = Field("trading:last_processed_ts", alias="TRADING_LAST_TS_HASH")
     redis_poll_timeout: int = Field(1, alias="TRADING_QUEUE_POLL_TIMEOUT")
     price_monitor_interval_seconds: int = Field(
@@ -172,6 +173,10 @@ class TradingConfig(BaseSettings):
                     max_spread_bps=10.0,
                 )
             ]
+        if self.decision_hmac_secret is not None:
+            self.decision_hmac_secret = self.decision_hmac_secret.strip() or None
+        if not self.dry_run and not self.decision_hmac_secret:
+            raise ValueError("TRADING_DECISION_HMAC_SECRET must be provided when TRADING_DRY_RUN=false")
         self._apply_shadow_overrides()
         # Normalize paths
         self.models_root = Path(self.models_root).expanduser().resolve()

--- a/algo-data-ingestion/app/trading/service.py
+++ b/algo-data-ingestion/app/trading/service.py
@@ -45,6 +45,7 @@ from app.trading.audit import TradingAuditLogger
 from app.trading.config import TradingConfig, TradingModelConfig
 from app.trading.executor import IntentLedger, IntentStatus, OrderDecision, OrderExecutor
 from app.trading.deadlock import DeadlockMonitor, DeadlockPolicy
+from app.decision_auth import verify_decision_message
 from app.trading.decision import TriggerConfig, DecisionOutcome, SAFE_MODE_ENV, KILL_SWITCH_ENV, decide_bar
 from app.trading.risk import assess_and_adjust_order
 from app.trading.state import PositionState, TradingStateStore
@@ -1855,6 +1856,13 @@ class TradingService:
             message = json.loads(raw)
         except json.JSONDecodeError:
             logger.warning("Discarding malformed payload: %s", raw[:80])
+            return
+        if not isinstance(message, dict):
+            logger.warning("Discarding non-object decision payload")
+            return
+        signature_ok, signature_reason = verify_decision_message(message, self.config.decision_hmac_secret)
+        if not signature_ok:
+            logger.warning("Discarding unauthenticated decision payload: %s", signature_reason)
             return
 
         model_label = str(message.get("model") or "")

--- a/algo-data-ingestion/docker-compose.yml
+++ b/algo-data-ingestion/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   redis:
     image: redis:7
     command: ["redis-server", "--appendonly", "yes"]
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -114,6 +112,7 @@ services:
       - DATA_LAKE_ROOT=/app/data_lake/market
       - DECISION_QUEUE_URL=redis://redis:6379/0
       - DECISION_QUEUE_KEY=trading:decisions
+      - TRADING_DECISION_HMAC_SECRET=${TRADING_DECISION_HMAC_SECRET:?set a strong scheduler/trading decision HMAC secret}
       - EXCHANGE_SANDBOX_MODE=0
       - INFER_DEFAULT_STRIDE=1
       - INFER_HISTORY_MARGIN_MIN=30
@@ -165,6 +164,7 @@ services:
     environment:
       - DECISION_QUEUE_URL=redis://redis:6379/0
       - DECISION_QUEUE_KEY=trading:decisions
+      - TRADING_DECISION_HMAC_SECRET=${TRADING_DECISION_HMAC_SECRET:?set a strong scheduler/trading decision HMAC secret}
       - MODELS_ROOT=/opt/models
       - EXCHANGE_SANDBOX_MODE=0
       - EXCHANGE_API_KEY=

--- a/algo-data-ingestion/tests/test_decision_auth.py
+++ b/algo-data-ingestion/tests/test_decision_auth.py
@@ -1,0 +1,21 @@
+from app.decision_auth import sign_decision_message, verify_decision_message
+
+
+def test_decision_auth_signs_and_detects_tampering():
+    message = {
+        "model": "xgb_primary",
+        "symbol": "BTC/USDT",
+        "timestamp": "2025-10-01T00:00:00+00:00",
+        "probability": 0.9,
+        "gate_pass": True,
+    }
+    signed = sign_decision_message(message, "test-secret")
+
+    assert signed["decision_signature_algorithm"] == "HMAC-SHA256"
+    assert verify_decision_message(signed, "test-secret") == (True, "ok")
+
+    tampered = dict(signed)
+    tampered["probability"] = 0.1
+    ok, reason = verify_decision_message(tampered, "test-secret")
+    assert ok is False
+    assert reason == "invalid_decision_signature"

--- a/algo-data-ingestion/tests/trading/test_service.py
+++ b/algo-data-ingestion/tests/trading/test_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import pytest
 
+from app.decision_auth import sign_decision_message
 from app.trading.config import TradingConfig
 from app.trading.executor import IntentLedger, OrderDecision, OrderExecutor
 from app.trading.service import ManifestSnapshot, TradingService, _extract_price_from_item
@@ -216,6 +217,88 @@ def test_portfolio_state_counts_pending_intents(tmp_path: Path, monkeypatch):
 
     _run(_test())
 
+
+def test_live_trading_requires_decision_hmac_secret(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv(
+        "TRADING_MODELS",
+        json.dumps(
+            [
+                {
+                    "model": "xgb_primary",
+                    "exchange": "binance",
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1m",
+                    "order_notional": 50.0,
+                    "max_spread_bps": 10.0,
+                }
+            ]
+        ),
+    )
+    _set_file_backends(monkeypatch)
+
+    with pytest.raises(ValueError, match="TRADING_DECISION_HMAC_SECRET"):
+        TradingConfig(
+            decision_queue_url="redis://example:6379/0",
+            decision_queue_key="queue",
+            state_path=tmp_path / "state.json",
+            models_root=tmp_path,
+            dry_run=False,
+            state_backend="file",
+        )
+
+
+def test_trading_service_rejects_unsigned_decision_when_secret_configured(tmp_path: Path, monkeypatch):
+    async def _test():
+        monkeypatch.setenv(
+            "TRADING_MODELS",
+            json.dumps(
+                [
+                    {
+                        "model": "xgb_primary",
+                        "exchange": "binance",
+                        "symbol": "BTC/USDT",
+                        "timeframe": "1m",
+                        "order_notional": 50.0,
+                        "max_spread_bps": 10.0,
+                    }
+                ]
+            ),
+        )
+        _set_file_backends(monkeypatch)
+        cfg = TradingConfig(
+            decision_queue_url="redis://example:6379/0",
+            decision_queue_key="queue",
+            state_path=tmp_path / "state.json",
+            models_root=tmp_path,
+            dry_run=True,
+            state_backend="file",
+            decision_hmac_secret="test-secret",
+        )
+        service = TradingService(cfg)
+        fake_executor = FakeExecutor()
+        service.executor = fake_executor
+        service._resolve_manifest = lambda payload, model_label, symbol_hint=None: ManifestSnapshot(
+            entry_threshold=0.5,
+            exit_threshold=0.5,
+            exit_prob_drop=0.1,
+            min_hold_bars=1,
+            long_only=True,
+        )
+
+        unsigned = {
+            "model": "xgb_primary",
+            "symbol": "BTC/USDT",
+            "items": [
+                {"timestamp": "2025-10-01T00:00:00+00:00", "probability": 0.9, "gate_pass": True}
+            ],
+        }
+        await service._handle_payload(json.dumps(unsigned))
+        assert fake_executor.calls == []
+
+        await service._handle_payload(json.dumps(sign_decision_message(unsigned, "test-secret")))
+        assert [call["side"] for call in fake_executor.calls] == ["buy"]
+
+    _run(_test())
 
 def test_extract_price_from_nested_features():
     item = {"features": {"close": 123.45}}
@@ -846,6 +929,7 @@ def test_shadow_mode_blocks_position_and_logs(tmp_path: Path, monkeypatch):
             state_path=tmp_path / "state.json",
             models_root=tmp_path,
             dry_run=False,
+            decision_hmac_secret="test-secret",
             state_backend="file",
             shadow_symbols=["BTC/USDT"],
         )
@@ -1024,6 +1108,7 @@ def test_reconciliation_mismatch_latches_safe_mode(tmp_path: Path, monkeypatch):
             state_path=tmp_path / "state.json",
             models_root=tmp_path,
             dry_run=False,
+            decision_hmac_secret="test-secret",
             state_backend="file",
             reconcile_healthy_streak=2,
         )
@@ -1082,6 +1167,7 @@ def test_reconciliation_clears_safe_mode_after_healthy_streak(tmp_path: Path, mo
             state_path=tmp_path / "state.json",
             models_root=tmp_path,
             dry_run=False,
+            decision_hmac_secret="test-secret",
             state_backend="file",
             reconcile_healthy_streak=2,
         )


### PR DESCRIPTION
### Motivation
- The scheduler and trading worker relied on an unauthenticated Redis list for trading decisions, creating a network-exposed trust boundary that allowed forged messages to trigger live orders.
- The change aims to close that trust boundary by ensuring decisions are authenticated end-to-end while preserving dry-run/demo compatibility.

### Description
- Add a deterministic HMAC helper `app/decision_auth.py` that canonicalises decision payloads and provides `sign_decision_message` and `verify_decision_message` (HMAC-SHA256).
- Have the scheduler sign each enqueued decision using `TRADING_DECISION_HMAC_SECRET` before `RPUSH`ing the JSON payloads.
- Add `decision_hmac_secret` to `TradingConfig` and require a non-empty `TRADING_DECISION_HMAC_SECRET` when `TRADING_DRY_RUN=false` to fail-closed for live trading.
- Make the trading worker verify incoming decision payloads and reject non-object, unsigned, or tampered messages when a secret is configured.
- Harden compose defaults by removing the host Redis port publication and requiring `TRADING_DECISION_HMAC_SECRET` in scheduler/trading container environments, and document the secret in `.env.example`.
- Add unit tests for signing/verification and for the trading service behavior when a decision HMAC secret is configured (`tests/test_decision_auth.py` and updates to `tests/trading/test_service.py`).

### Testing
- `python -m py_compile app/decision_auth.py app/trading/config.py app/trading/service.py app/scheduler/main.py` succeeded.
- Ran the new unit test `pytest -q tests/test_decision_auth.py` which passed.
- Attempted `pytest -q tests/trading/test_service.py`, but running the full test file in this environment was blocked by an optional native dependency (`torch`) required by existing test imports, so full trading test coverage could not be executed here.
- Attempted to validate `docker compose` configuration rendering with an example secret, but that check could not be run because `docker` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076814e184832aae7931e673bf7a59)